### PR TITLE
Added support for HLK-LD2420 presence sensors.

### DIFF
--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -18,17 +18,18 @@
 #define BIT_PRESENCE 1024
 
 #define SENS_NO 0
-#define SENS_SHT3X 1     // Temp/Hum
-#define SENS_BME280 2    // Temp/Hum/Pressure
-#define SENS_BME680 3    // Temp/Hum/Pressure/Voc
-#define SENS_SCD30 4     // Temp/Hum/Co2
-#define SENS_IAQCORE 5   // Voc
-#define SENS_OPT300X 6   // Lux
-#define SENS_VL53L1X 7   // Tof
-#define SENS_SGP30 8     // Temp/Hum/Voc
-#define SENS_SCD41 9     // Temp/Hum/Co2
-#define SENS_MR24xxB1 10 // HF-Presence
-#define SENS_VEML7700 11 // Lux
+#define SENS_SHT3X 1      // Temp/Hum
+#define SENS_BME280 2     // Temp/Hum/Pressure
+#define SENS_BME680 3     // Temp/Hum/Pressure/Voc
+#define SENS_SCD30 4      // Temp/Hum/Co2
+#define SENS_IAQCORE 5    // Voc
+#define SENS_OPT300X 6    // Lux
+#define SENS_VL53L1X 7    // Tof
+#define SENS_SGP30 8      // Temp/Hum/Voc
+#define SENS_SCD41 9      // Temp/Hum/Co2
+#define SENS_MR24xxB1 10  // HF-Presence
+#define SENS_VEML7700 11  // Lux
+#define SENS_HLKLD2420 12 // HF-Presence
 
 enum SensorState
 {

--- a/src/Sensor.h
+++ b/src/Sensor.h
@@ -55,7 +55,8 @@ enum MeasureType
     Pres = 1024,
     Speed = 2048,
     Sensitivity = 4096,
-    Scenario = 8192
+    Scenario = 8192,
+    Distance = 16384
 };
 
 #if defined(SENSORMODULE) || defined(PMMODULE)

--- a/src/SensorFactory.cpp
+++ b/src/SensorFactory.cpp
@@ -13,6 +13,7 @@
     #include "SensorSGP30.h"
     #include "SensorSHT3x.h"
     #include "SensorVEML7700.h"
+    #include "SensorHLKLD2420.h"
     #include "SensorVL53L1X.h"
 
 Sensor* newSensor(uint8_t iSensorClass, MeasureType iMeasureType)
@@ -67,6 +68,9 @@ Sensor* newSensor(uint8_t iSensorClass, MeasureType iMeasureType)
         #ifdef HF_POWER_PIN
         case SENS_MR24xxB1:
             lSensor = new SensorMR24xxB1(iMeasureType);
+            break;
+        case SENS_HLKLD2420:
+            lSensor = new SensorHLKLD2420(iMeasureType);
             break;
         #endif
     #endif

--- a/src/SensorHLKLD2420.cpp
+++ b/src/SensorHLKLD2420.cpp
@@ -1,0 +1,636 @@
+// #include "IncludeManager.h"
+#ifdef PMMODULE
+    #ifdef SERIAL_HF
+        #include "SensorHLKLD2420.h"
+        #include <Arduino.h>
+        #include <Wire.h>
+
+SensorHLKLD2420::SensorHLKLD2420(uint16_t iMeasureTypes)
+    : SensorHLKLD2420(iMeasureTypes, 0){};
+
+SensorHLKLD2420::SensorHLKLD2420(uint16_t iMeasureTypes, uint8_t iAddress)
+    : Sensor(iMeasureTypes, iAddress)
+{
+    gMeasureTypes |= Pres | Sensitivity | Scenario;
+};
+
+void SensorHLKLD2420::defaultSensorParameters(int8_t iScenario, uint8_t iSensitivity)
+{
+    mDefaultScenario = iScenario;
+    mDefaultSensitivity = iSensitivity;
+}
+
+uint8_t SensorHLKLD2420::getSensorClass()
+{
+    return SENS_HLKLD2420;
+}
+
+void SensorHLKLD2420::sensorLoopInternal()
+{
+    switch (gSensorState)
+    {
+        case Wakeup:
+            Sensor::sensorLoopInternal();
+            break;
+        case Calibrate:
+            if (delayCheck(pSensorStateDelay, 50))
+            {
+                gSensorState = Finalize;
+                pSensorStateDelay = millis();
+            }
+            break;
+        case Finalize:
+            if (delayCheck(pSensorStateDelay, 50))
+            {
+                gSensorState = Running;
+                pSensorStateDelay = millis();
+            }
+            break;
+        case Running:
+            uartGetPacket();
+            sendDefaultSensorValues();
+            break;
+        default:
+            pSensorStateDelay = millis();
+            break;
+    }
+}
+
+// this state engine calculates startup behaviour of HF sensor
+// and sends default values as soon as the sensor can consume them
+void SensorHLKLD2420::sendDefaultSensorValues()
+{
+    // SERIAL_DEBUG.printf("sendDefaultSensorValues: %d, %.2f\n", mHfSensorStartupStates, lastDetectedRange);
+    switch (mHfSensorStartupStates)
+    {
+        case START_INIT:
+            if (lastDetectedRange > NO_NUM)
+            {
+                pSensorStateDelay = millis();
+                mHfSensorStartupStates = START_SENSOR_ACTIVE;
+
+                sendCommand(CMD_OPEN_COMMAND_MODE, PARAM_OPEN_COMMAND_MODE);
+            }
+            break;
+        case START_SENSOR_ACTIVE:
+            // Communication is established, we wait for version info from Sensor
+            if (delayCheck(pSensorStateDelay, 1000))
+            {
+                pSensorStateDelay = millis();
+                if (!moduleVersion.empty())
+                {
+                    mHfSensorStartupStates = START_VERSION_RECEIVED;
+                }
+                else
+                {
+                    sendCommand(CMD_READ_VERSION);
+                }
+            }
+            break;
+        case START_VERSION_RECEIVED:
+            // We got version, we wait for read 1 done
+            if (delayCheck(pSensorStateDelay, 2000))
+            {
+                pSensorStateDelay = millis();
+                if (minDistance > NO_NUM)
+                {
+                    mHfSensorStartupStates = START_READ1_DONE;
+                }
+                else
+                {
+                    sendCommand(CMD_READ_MODULE_CONFIG, PARAM_READ_DISTANCE_TRIGGER);
+                }
+            }
+            break;
+        case START_READ1_DONE:
+            // Read 1 is done, we wait for read 2 done
+            if (delayCheck(pSensorStateDelay, 2000))
+            {
+                pSensorStateDelay = millis();
+                if (delayTime > NO_NUM)
+                {
+                    mHfSensorStartupStates = START_READ2_DONE;
+                }
+                else
+                {
+                    sendCommand(CMD_READ_MODULE_CONFIG, PARAM_READ_DELAY_MAINTAIN);
+                }
+            }
+            break;
+        case START_READ2_DONE:
+            // All done, close command mode again
+            if (delayCheck(pSensorStateDelay, 1000))
+            {
+                pSensorStateDelay = millis();
+                mHfSensorStartupStates = START_FINISHED;
+
+                resetRawDataRecording();
+                sendCommand(CMD_RAW_DATA_MODE, PARAM_RAW_DATA_MODE);
+
+                sendCommand(CMD_CLOSE_COMMAND_MODE);
+            }
+            break;
+        default:
+            mHfSensorStartupStates = START_FINISHED;
+            break;
+    }
+}
+
+void SensorHLKLD2420::uartGetPacket()
+{
+    uint8_t rxByte;
+    switch (mPacketState)
+    {
+        case GET_SYNC_STATE:
+            // wait for a valid header
+            while (mPacketState == GET_SYNC_STATE)
+            {
+                if (SERIAL_HF.available() > 0 && SERIAL_HF.readBytes(&rxByte, 1) == 1)
+                {
+                    // SERIAL_DEBUG.print("Sync-Byte: ");
+                    // SERIAL_DEBUG.print(rxByte < 16 ? "0" : "");
+                    // SERIAL_DEBUG.print(rxByte, HEX);
+                    // SERIAL_DEBUG.println();
+                    mBuffer.push_back((byte)rxByte);
+                    if (mBuffer.size() == HEADER_FOOTER_SIZE)
+                    {
+                        if (mBuffer == HEADER_ON)
+                        {
+                            mPacketType = ON;
+                            mPacketState = GET_PACKET_DATA;
+                            break;
+                        }
+                        if (mBuffer == HEADER_OFF)
+                        {
+                            mPacketType = OFF;
+                            mPacketState = GET_PACKET_DATA;
+                            break;
+                        }
+                        if (mBuffer == HEADER_COMMAND)
+                        {
+                            mPacketType = COMMAND_RESPONSE;
+                            mPacketState = GET_PACKET_DATA;
+                            break;
+                        }
+                        if (mBuffer == HEADER_RAW_DATA)
+                        {
+                            mPacketType = RAW_DATA;
+                            mPacketState = GET_PACKET_DATA;
+                            break;
+                        }
+                    }
+
+                    // if the current buffer is the expected size of the header,
+                    // but we did not find a valid header yet, we remove the first element
+                    if (mBuffer.size() == HEADER_FOOTER_SIZE)
+                    {
+                        mBuffer.erase(mBuffer.begin());
+                    }
+                }
+                else if (delayCheck(pSensorStateDelay, 1000))
+                {
+                    // no data received for 1 sec., cancel header sync
+                    break;
+                }
+            }
+            break;
+        case GET_PACKET_DATA:
+            // add data till valid footer received
+            while (mPacketState == GET_PACKET_DATA)
+            {
+                if (SERIAL_HF.available() > 0 && SERIAL_HF.readBytes(&rxByte, 1) == 1)
+                {
+                    // SERIAL_DEBUG.print("Get-Byte: ");
+                    // SERIAL_DEBUG.print(rxByte < 16 ? "0" : "");
+                    // SERIAL_DEBUG.print(rxByte, HEX);
+                    // SERIAL_DEBUG.println();
+                    // if (mBuffer.size() % 10 == 0)
+                    //     SERIAL_DEBUG.println(mBuffer.size());
+
+                    mBuffer.push_back((byte)rxByte);
+                    if (mPacketType == COMMAND_RESPONSE && equal(mBuffer.end() - HEADER_FOOTER_SIZE, mBuffer.end(), FOOTER.begin()) ||
+                        mPacketType == RAW_DATA && equal(mBuffer.end() - HEADER_FOOTER_SIZE, mBuffer.end(), FOOTER_RAW_DATA.begin()))
+                    {
+                        mPacketState = PROCESS_PACKET_STATE;
+                        break;
+                    }
+
+                    if ((mPacketType == OFF || mPacketType == ON && mBuffer.size() > 10) &&
+                        mBuffer.end()[-2] == 13 && mBuffer.end()[-1] == 10)
+                    { // new line
+                        mPacketState = PROCESS_PACKET_STATE;
+                        break;
+                    }
+                }
+                else if (delayCheck(pSensorStateDelay, 1000))
+                {
+                    // no data received for 1 sec., cancel get packet data
+                    break;
+                }
+            }
+            break;
+        case PROCESS_PACKET_STATE:
+            getSensorData();
+            mBuffer.clear();
+            mPacketState = GET_SYNC_STATE;
+            break;
+    }
+}
+
+int SensorHLKLD2420::bytesToInt(byte byte0, byte byte1, byte byte2, byte byte3)
+{
+    return int((unsigned char)(byte3) << 24 |
+               (unsigned char)(byte2) << 16 |
+               (unsigned char)(byte1) << 8 |
+               (unsigned char)(byte0));
+}
+
+std::vector<byte> SensorHLKLD2420::intToBytes(int intValue)
+{
+    std::vector<byte> bytes;
+
+    bytes.push_back((byte)(intValue & 0xFF));
+    bytes.push_back((byte)((intValue >> 8) & 0xFF));
+    bytes.push_back((byte)((intValue >> 16) & 0xFF));
+    bytes.push_back((byte)((intValue >> 24) & 0xFF));
+    return bytes;
+}
+
+double SensorHLKLD2420::rawToDb(int rawValue)
+{
+    return 10 * log10(rawValue);
+}
+
+int SensorHLKLD2420::dBToRaw(double dbValue)
+{
+    return int(pow(10, dbValue / 10));
+}
+
+void SensorHLKLD2420::resetRawDataRecording()
+{
+    for (int i = 0; i < 16; i++)
+    {
+        rawDataRangeAverage[i] = 0;
+    }
+
+    rawDataLastRecordingReceived = millis();
+    rawDataRecordingCount = 0;
+}
+
+bool SensorHLKLD2420::getSensorData()
+{
+    bool result = false;
+
+    std::string rangeString;
+    float newDetectedRange;
+
+    bool success;
+    std::string successMessage;
+
+    int payloadSize;
+
+    int rangeMax[16] = {};
+    int dopplerOffset;
+    int rangeOffset;
+    int rangeValue;
+
+    switch (mPacketType)
+    {
+        case ON:
+            // cut 10 bytes at the beginning: 4F 4E 0D 0A 52 61 6E 67 65 20 ("ON  RANGE ")
+            // and 2 bytes at the end
+            mBuffer.erase(mBuffer.begin(), mBuffer.begin() + 10);
+            mBuffer.erase(mBuffer.end() - 2, mBuffer.end());
+
+            // mBuffer now holds the detection range decimal value as string
+            rangeString = std::string(reinterpret_cast<const char *>(&mBuffer[0]), mBuffer.size());
+            newDetectedRange = stoi(rangeString) / (float)10;
+
+            if (lastDetectedRange != newDetectedRange)
+            {
+                lastDetectedRange = newDetectedRange;
+                SERIAL_DEBUG.printf("Presence detected, range: %.1f m\n", lastDetectedRange);
+            }
+
+            result = true;
+            break;
+
+        case OFF:
+            if (lastDetectedRange != -1)
+            {
+                lastDetectedRange = -1;
+                SERIAL_DEBUG.println("No presence detected");
+            }
+
+            result = true;
+            break;
+
+        case COMMAND_RESPONSE:
+            payloadSize = int(mBuffer[4]);
+
+            // cut 6 bytes (4 header + 2 size) at the beginning and 4 bytes footer at the end
+            mBuffer.erase(mBuffer.begin(), mBuffer.begin() + 6);
+            mBuffer.erase(mBuffer.end() - 4, mBuffer.end());
+
+            if (mBuffer.size() != payloadSize)
+            {
+                SERIAL_DEBUG.printf("Invalid command reponse packet size: %d\n", mBuffer.size());
+                break;
+            }
+
+            // we expect "01 00 00" after the command code for success
+            success = mBuffer[1] == (byte)1 && mBuffer[2] == (byte)0 && mBuffer[3] == (byte)0;
+            successMessage = success ? "success" : "failed";
+
+            switch (mBuffer[0])
+            {
+                case CMD_OPEN_COMMAND_MODE:
+                    SERIAL_DEBUG.printf("Received response: CMD_OPEN_COMMAND_MODE (%s)\n", successMessage.c_str());
+                    result = true;
+                    break;
+                case CMD_CLOSE_COMMAND_MODE:
+                    SERIAL_DEBUG.printf("Received response: CMD_CLOSE_COMMAND_MODE (%s)\n", successMessage.c_str());
+                    result = true;
+                    break;
+                case CMD_READ_VERSION:
+                    SERIAL_DEBUG.printf("Received response: CMD_READ_VERSION (%s)\n", successMessage.c_str());
+
+                    if (!success)
+                        break;
+
+                    // cut 6 bytes at the beginning: 00 01 00 00 06 00
+                    mBuffer.erase(mBuffer.begin(), mBuffer.begin() + 6);
+
+                    // mBuffer now holds the version value as string
+                    moduleVersion = std::string(reinterpret_cast<const char *>(&mBuffer[0]), mBuffer.size());
+                    SERIAL_DEBUG.printf("Module version: %s\n", moduleVersion.c_str());
+                    result = true;
+                    break;
+                case CMD_READ_MODULE_CONFIG:
+                    SERIAL_DEBUG.printf("Received response: CMD_READ_MODULE_CONFIG (%s)\n", successMessage.c_str());
+
+                    if (!success)
+                        break;
+
+                    // We only support 2 types of read requests:
+                    // - Read both distance and all trigger thresholds (= in total 18)
+                    // - Read the delay and all metain thresholds (= in total 17)
+                    // This way, based on the returned amount of data we can recognize which read request was fullfilled.
+
+                    // cut 4 bytes at the beginning: 08 01 00 00
+                    mBuffer.erase(mBuffer.begin(), mBuffer.begin() + 4);
+
+                    if (payloadSize == 0x4C)
+                    { // 76 - 4 = 72 bytes (18 x 4 bytes)
+                        // - Read both distance and all trigger thresholds (= in total 18)
+
+                        minDistance = bytesToInt(mBuffer[0], mBuffer[1], mBuffer[2], mBuffer[3]);
+                        SERIAL_DEBUG.printf("minDistance: %d\n", minDistance);
+
+                        maxDistance = bytesToInt(mBuffer[4], mBuffer[5], mBuffer[6], mBuffer[7]);
+                        SERIAL_DEBUG.printf("maxDistance: %d\n", maxDistance);
+
+                        SERIAL_DEBUG.print("triggerThreshold:");
+                        for (int i = 0; i < 16; i++)
+                        {
+                            triggerThreshold[i] = bytesToInt(mBuffer[i * 4 + 8], mBuffer[i * 4 + 9], mBuffer[i * 4 + 10], mBuffer[i * 4 + 11]);
+                            SERIAL_DEBUG.printf(" %.2f", rawToDb(triggerThreshold[i]));
+                        }
+                        SERIAL_DEBUG.println();
+                    }
+                    else if (payloadSize == 0x48)
+                    { // 72 - 4 = 68 bytes (17 x 4 bytes)
+                        // - Read the delay and all metain thresholds (= in total 17)
+
+                        delayTime = bytesToInt(mBuffer[0], mBuffer[1], mBuffer[2], mBuffer[3]);
+                        SERIAL_DEBUG.printf("delayTime: %d\n", delayTime);
+
+                        SERIAL_DEBUG.print("holdThreshold:");
+                        for (int i = 0; i < 16; i++)
+                        {
+                            holdThreshold[i] = bytesToInt(mBuffer[i * 4 + 4], mBuffer[i * 4 + 5], mBuffer[i * 4 + 6], mBuffer[i * 4 + 7]);
+                            SERIAL_DEBUG.printf(" %.2f", rawToDb(holdThreshold[i]));
+                        }
+                        SERIAL_DEBUG.println();
+                    }
+                    else
+                    {
+                        SERIAL_DEBUG.printf("Unknown read response, payload size: %d\n", payloadSize);
+                        break;
+                    }
+
+                    result = true;
+                    break;
+                case CMD_WRITE_MODULE_CONFIG:
+                    SERIAL_DEBUG.printf("Received response: CMD_WRITE_MODULE_CONFIG (%s)\n", successMessage.c_str());
+                    result = true;
+                    break;
+                case CMD_RAW_DATA_MODE:
+                    SERIAL_DEBUG.printf("Received response: CMD_RAW_DATA_MODE (%s)\n", successMessage.c_str());
+                    result = true;
+                    break;
+                default:
+                    SERIAL_DEBUG.printf("Unknown response code: %d (%s)\n", mBuffer[0], successMessage.c_str());
+                    break;
+            }
+
+            break;
+
+        case RAW_DATA:
+            // cut 4 bytes at the beginning and 4 bytes footer at the end
+            mBuffer.erase(mBuffer.begin(), mBuffer.begin() + 4);
+            mBuffer.erase(mBuffer.end() - 4, mBuffer.end());
+
+            for (int i = 0; i < 20; i++)
+            {
+                dopplerOffset = i * 64;
+
+                for (int j = 0; j < 16; j++)
+                {
+                    rangeOffset = dopplerOffset + j * 4;
+                    rangeValue = bytesToInt(mBuffer[rangeOffset], mBuffer[rangeOffset + 1], mBuffer[rangeOffset + 2], mBuffer[rangeOffset + 3]);
+                    rangeMax[j] = max(rangeMax[j], rangeValue);
+                }
+            }
+
+        #ifdef debugOutput
+            SERIAL_DEBUG.printf("Range values received (%d):", rawDataRecordingCount);
+            for (int i = 0; i < 16; i++)
+            {
+                SERIAL_DEBUG.printf(" %.2f", rawToDb(rangeMax[i]));
+            }
+            SERIAL_DEBUG.println();
+        #endif
+
+            // if more than 1 sec. past since last raw data value (should be 4-5/sec.),
+            // something when wrong, start recording from scratch
+            if (delayCheck(rawDataLastRecordingReceived, 1000))
+            {
+                resetRawDataRecording();
+            }
+            else if (rawDataRecordingCount < CALIBRATION_VALUE_COUNT)
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    // calculate rolling average
+                    rawDataRangeAverage[i] -= rawDataRangeAverage[i] / CALIBRATION_VALUE_COUNT;
+                    rawDataRangeAverage[i] += (double)rangeMax[i] / CALIBRATION_VALUE_COUNT;
+                }
+                rawDataRecordingCount++;
+
+                rawDataLastRecordingReceived = millis();
+            }
+
+            if (rawDataRecordingCount >= CALIBRATION_VALUE_COUNT)
+            {
+                // enter command mode to stop raw data transfer
+                sendCommand(CMD_OPEN_COMMAND_MODE, PARAM_OPEN_COMMAND_MODE);
+
+                // convert to dB values and add trigger offset
+                double triggerThresholdDb[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    triggerThresholdDb[i] = rawToDb(rawDataRangeAverage[i]) + CALIBRATION_TRIGGER_OFFSET_DB;
+                }
+
+                // substract hold offset
+                double holdThresholdDb[16];
+                for (int i = 0; i < 16; i++)
+                {
+                    holdThresholdDb[i] = triggerThresholdDb[i] - CALIBRATION_HOLD_OFFSET_DB;
+                }
+
+        #ifdef debugOutput
+                SERIAL_DEBUG.print("rawDataRangeAverage:");
+                for (int i = 0; i < 16; i++)
+                {
+                    SERIAL_DEBUG.printf(" %.2f", rawDataRangeAverage[i]);
+                }
+                SERIAL_DEBUG.println();
+                SERIAL_DEBUG.print("triggerThresholdDb:");
+                for (int i = 0; i < 16; i++)
+                {
+                    SERIAL_DEBUG.printf(" %.2f", triggerThresholdDb[i]);
+                }
+                SERIAL_DEBUG.println();
+                SERIAL_DEBUG.print("holdThresholdDb:");
+                for (int i = 0; i < 16; i++)
+                {
+                    SERIAL_DEBUG.printf(" %.2f", holdThresholdDb[i]);
+                }
+                SERIAL_DEBUG.println();
+        #endif
+
+                // write back trigger thresholds, for each:
+                // first 2 bytes parameter offset, then 4 bytes value
+                std::vector<byte> param;
+                std::vector<byte> bytes;
+                for (int i = 0; i < 16; i++)
+                {
+                    param.push_back(OFFSET_PARAM_TRIGGERS + (byte)i);
+                    param.push_back(0);
+
+                    bytes = intToBytes(dBToRaw(triggerThresholdDb[i]));
+                    param.insert(param.end(), bytes.cbegin(), bytes.cend());
+                }
+                // sendCommand(CMD_WRITE_MODULE_CONFIG, param);
+
+                // write back hold thresholds, for each:
+                // first 2 bytes parameter offset, then 4 bytes value
+                param.clear();
+                for (int i = 0; i < 16; i++)
+                {
+                    param.push_back(OFFSET_PARAM_HOLDS + (byte)i);
+                    param.push_back(0);
+
+                    bytes = intToBytes(dBToRaw(holdThresholdDb[i]));
+                    param.insert(param.end(), bytes.cbegin(), bytes.cend());
+                }
+                // sendCommand(CMD_WRITE_MODULE_CONFIG, param);
+
+                // reboot module to return to normal (not raw data) operation
+                sendCommand(CMD_REBOOT_MODULE);
+            }
+
+            result = true;
+            break;
+
+        default:
+            SERIAL_DEBUG.printf("Unknown packet type: %d\n", mPacketType);
+            break;
+    }
+
+    return result;
+}
+
+void SensorHLKLD2420::sendCommand(byte command, std::vector<byte> paramter)
+{
+    std::vector<byte> cmdData = HEADER_COMMAND;
+
+    byte payloadSize = 2 + paramter.size();
+    cmdData.push_back(payloadSize);
+    cmdData.push_back(0x00);
+
+    cmdData.push_back(command);
+    cmdData.push_back(0x00);
+
+    cmdData.insert(cmdData.end(), paramter.cbegin(), paramter.cend());
+    cmdData.insert(cmdData.end(), FOOTER.cbegin(), FOOTER.cend());
+
+    const char *cmdDataRaw = reinterpret_cast<const char *>(cmdData.data());
+    SERIAL_HF.write(cmdDataRaw, cmdData.size());
+
+        #ifdef debugOutput
+    SERIAL_DEBUG.print("Sending to sensor: ");
+    for (int i = 0; i < cmdData.size(); i++)
+    {
+        SERIAL_DEBUG.print(cmdData[i] < 16 ? "0" : "");
+        SERIAL_DEBUG.print(cmdData[i], HEX);
+        SERIAL_DEBUG.print(" ");
+    }
+    SERIAL_DEBUG.println();
+        #endif
+}
+
+float SensorHLKLD2420::measureValue(MeasureType iMeasureType)
+{
+    if (mHfSensorStartupStates < START_FINISHED)
+        return NO_NUM;
+    switch (iMeasureType)
+    {
+        case Pres:
+            return lastDetectedRange;
+            break;
+        case Sensitivity:
+            if (mSensitivity >= 0)
+                return mSensitivity;
+            break;
+        case Scenario:
+            if (mScenario >= 0)
+                return mScenario;
+            break;
+        default:
+            break;
+    }
+    return NO_NUM;
+}
+
+bool SensorHLKLD2420::checkSensorConnection()
+{
+    return true;
+}
+
+bool SensorHLKLD2420::begin()
+{
+    printDebug("Starting sensor HLK-LD2420 (Presence)... ");
+    bool lResult = Sensor::begin();
+    printResult(lResult);
+    return lResult;
+}
+
+uint8_t SensorHLKLD2420::getI2cSpeed()
+{
+    return 10; // n * 100kHz // no I2C, so we support "all" frequencies :-)
+}
+    #endif
+#endif

--- a/src/SensorHLKLD2420.cpp
+++ b/src/SensorHLKLD2420.cpp
@@ -1,9 +1,9 @@
 // #include "IncludeManager.h"
 #ifdef PMMODULE
-    #ifdef SERIAL_HF
-        #include "SensorHLKLD2420.h"
-        #include <Arduino.h>
-        #include <Wire.h>
+#ifdef SERIAL_HF
+#include <Arduino.h>
+#include <Wire.h>
+#include "SensorHLKLD2420.h"
 
 SensorHLKLD2420::SensorHLKLD2420(uint16_t iMeasureTypes)
     : SensorHLKLD2420(iMeasureTypes, 0){};
@@ -622,9 +622,9 @@ bool SensorHLKLD2420::checkSensorConnection()
 
 bool SensorHLKLD2420::begin()
 {
-    printDebug("Starting sensor HLK-LD2420 (Presence)... ");
+    SERIAL_DEBUG.println("Starting sensor HLK-LD2420 (Presence)... ");
     bool lResult = Sensor::begin();
-    printResult(lResult);
+    SERIAL_DEBUG.println(lResult);
     return lResult;
 }
 

--- a/src/SensorHLKLD2420.cpp
+++ b/src/SensorHLKLD2420.cpp
@@ -21,12 +21,12 @@ std::string SensorHLKLD2420::logPrefix()
 
 void SensorHLKLD2420::defaultSensorParameters(uint8_t iSensitivity)
 {
-    mDefaultSensitivity = iSensitivity;
+    mSensitivity = iSensitivity;
 }
 
 void SensorHLKLD2420::writeSensitivity(int8_t iSensitivity)
 {
-    mDefaultSensitivity = iSensitivity;
+    mSensitivity = iSensitivity;
 
     // restart calibration with new sensitivity value
     mHfSensorStartupStates = START_READ2_DONE;
@@ -520,7 +520,8 @@ bool SensorHLKLD2420::getSensorData()
                 logTraceP("rawDataRangeAverage:");
                 logIndentUp();
 
-                double triggerOffsetDb = CALIBRATION_TRIGGER_OFFSET_DB - SENSITIVIY_TRIGGER_RANGE * (mSensitivity / 10);
+                int8_t lSensitivity = mSensitivity > 0 && mSensitivity <= 10 ? mSensitivity : SENSITIVITY_DEFAULT;
+                double triggerOffsetDb = CALIBRATION_TRIGGER_OFFSET_DB - SENSITIVITY_TRIGGER_RANGE * (lSensitivity / 10.0);
 
                 // convert to dB values and add trigger offset
                 double triggerThresholdDb[16];
@@ -532,7 +533,7 @@ bool SensorHLKLD2420::getSensorData()
 
                 logIndentDown();
 
-                double holdOffsetDb = CALIBRATION_HOLD_OFFSET_DB - SENSITIVIY_HOLD_RANGE * (mSensitivity / 10);
+                double holdOffsetDb = CALIBRATION_HOLD_OFFSET_DB - SENSITIVITY_HOLD_RANGE * (lSensitivity / 10.0);
 
                 // substract hold offset
                 double holdThresholdDb[16];
@@ -540,6 +541,13 @@ bool SensorHLKLD2420::getSensorData()
                 {
                     holdThresholdDb[i] = triggerThresholdDb[i] - holdOffsetDb;
                 }
+
+                logDebugP("Sensitivity used:");
+                logIndentUp();
+                logDebugP("User setting: %d", mSensitivity);
+                logDebugP("Calculated trigger offset : %.2f", triggerOffsetDb);
+                logDebugP("Calculated hold offset: %.2f", holdOffsetDb);
+                logIndentDown();
 
                 logDebugP("Write config to sensor:");
                 logIndentUp();

--- a/src/SensorHLKLD2420.h
+++ b/src/SensorHLKLD2420.h
@@ -39,8 +39,9 @@ const std::vector<byte> PARAM_RAW_DATA_MODE = {(byte)0x00, (byte)0x00, (byte)0x0
 // these will be deducted from trigger/hold offset based on sensitivity percentage
 // e. g. sensitivity 5 (= 50 %): trigger offset 5-2=3, hold offset 2.5-1=1.5
 // lower offsets = higher sensitivity
-#define SENSITIVIY_TRIGGER_RANGE 4
-#define SENSITIVIY_HOLD_RANGE 2
+#define SENSITIVITY_TRIGGER_RANGE 4
+#define SENSITIVITY_HOLD_RANGE 2
+#define SENSITIVITY_DEFAULT 5 // in case user setting invalid
 
 #define START_INIT 0
 #define START_SENSOR_ACTIVE 1
@@ -108,7 +109,6 @@ class SensorHLKLD2420 : public Sensor
     uint8_t mPresence = -1;
     float mMoveSpeed = NO_NUM;
     int8_t mSensitivity = -1;
-    int8_t mScenario = -1;
     uint8_t getSensorClass() override; // returns unique ID for this sensor type
     void sensorLoopInternal() override;
     bool checkSensorConnection() override;

--- a/src/SensorHLKLD2420.h
+++ b/src/SensorHLKLD2420.h
@@ -1,0 +1,131 @@
+#pragma once
+// #include "IncludeManager.h"
+#ifdef PMMODULE
+#ifdef SERIAL_HF
+#include <string>
+#include <vector>
+#include "Sensor.h"
+
+#define HEADER_FOOTER_SIZE 4
+
+const std::vector<byte> HEADER_ON = {(byte)0x4F, (byte)0x4E, (byte)0x0D, (byte)0x0A};
+const std::vector<byte> HEADER_OFF = {(byte)0x4F, (byte)0x46, (byte)0x46, (byte)0x0D};
+const std::vector<byte> HEADER_COMMAND = {(byte)0xFD, (byte)0xFC, (byte)0xFB, (byte)0xFA};
+const std::vector<byte> FOOTER = {(byte)0x04, (byte)0x03, (byte)0x02, (byte)0x01};
+
+const std::vector<byte> HEADER_RAW_DATA = {(byte)0xAA, (byte)0xBF, (byte)0x10, (byte)0x14};
+const std::vector<byte> FOOTER_RAW_DATA = {(byte)0xFD, (byte)0xFC, (byte)0xFB, (byte)0xFA};
+
+#define CMD_OPEN_COMMAND_MODE 0xFF
+#define CMD_CLOSE_COMMAND_MODE 0xFE
+#define CMD_READ_VERSION 0x00
+#define CMD_REBOOT_MODULE 0x68
+#define CMD_READ_MODULE_CONFIG 0x08
+#define CMD_WRITE_MODULE_CONFIG 0x07
+#define CMD_RAW_DATA_MODE 0x12
+
+#define OFFSET_PARAM_TRIGGERS 0x10
+#define OFFSET_PARAM_HOLDS 0x20
+
+const std::vector<byte> PARAM_OPEN_COMMAND_MODE = {(byte)0x01, (byte)0x00};
+const std::vector<byte> PARAM_READ_DISTANCE_TRIGGER = {(byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x10, (byte)0x00, (byte)0x11, (byte)0x00, (byte)0x12, (byte)0x00, (byte)0x13, (byte)0x00, (byte)0x14, (byte)0x00, (byte)0x15, (byte)0x00, (byte)0x16, (byte)0x00, (byte)0x17, (byte)0x00, (byte)0x18, (byte)0x00, (byte)0x19, (byte)0x00, (byte)0x1A, (byte)0x00, (byte)0x1B, (byte)0x00, (byte)0x1C, (byte)0x00, (byte)0x1D, (byte)0x00, (byte)0x1E, (byte)0x00, (byte)0x1F, (byte)0x00};
+const std::vector<byte> PARAM_READ_DELAY_MAINTAIN = {(byte)0x04, (byte)0x00, (byte)0x20, (byte)0x00, (byte)0x21, (byte)0x00, (byte)0x22, (byte)0x00, (byte)0x23, (byte)0x00, (byte)0x24, (byte)0x00, (byte)0x25, (byte)0x00, (byte)0x26, (byte)0x00, (byte)0x27, (byte)0x00, (byte)0x28, (byte)0x00, (byte)0x29, (byte)0x00, (byte)0x2A, (byte)0x00, (byte)0x2B, (byte)0x00, (byte)0x2C, (byte)0x00, (byte)0x2D, (byte)0x00, (byte)0x2E, (byte)0x00, (byte)0x2F, (byte)0x00};
+const std::vector<byte> PARAM_RAW_DATA_MODE = {(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
+
+#define CALIBRATION_VALUE_COUNT 100
+#define CALIBRATION_TRIGGER_OFFSET_DB 3
+#define CALIBRATION_HOLD_OFFSET_DB 1.5
+
+
+#define START_INIT 0
+#define START_SENSOR_ACTIVE 1
+#define START_VERSION_RECEIVED 2
+#define START_READ1_DONE 3
+#define START_READ2_DONE 4
+#define START_FINISHED 255
+
+
+class SensorHLKLD2420 : public Sensor
+{
+  private:
+    //! uartGetPacket state machine states.
+    enum PacketStates
+    {
+        //! Waiting for the synchronisation byte 0x55
+        GET_SYNC_STATE = 0,
+        //! Reads message data in our buffer
+        GET_PACKET_DATA,
+        //! Process the correctly received packet
+        PROCESS_PACKET_STATE
+    };
+
+    enum PacketType
+    {
+        //! Presence detection on
+        ON = 0,
+        //! Presence detection off
+        OFF,
+        //! Command packet
+        COMMAND_RESPONSE,
+        //! Raw data packet
+        RAW_DATA
+    };
+
+    std::vector<byte> mBuffer; // message buffer
+    int mBufferIndex = 0;
+    PacketStates mPacketState = GET_SYNC_STATE;
+    PacketType mPacketType;
+    
+    std::string moduleVersion;
+    float lastDetectedRange = NO_NUM;
+    int minDistance = NO_NUM;
+    int maxDistance = NO_NUM;
+    int delayTime = NO_NUM;
+    int triggerThreshold[16];
+    int holdThreshold[16];
+
+    uint32_t rawDataLastRecordingReceived = 0;
+    double rawDataRangeAverage[16];
+    int rawDataRecordingCount = 0;
+    
+    int8_t mDefaultScenario = 0;
+    int8_t mDefaultSensitivity = 8;
+    uint8_t mHfSensorStartupStates = 0;
+
+    void uartGetPacket();
+    int bytesToInt(byte byte1, byte byte2, byte byte3, byte byte4);
+    std::vector<byte> intToBytes(int intValue);
+    double rawToDb(int rawValue);
+    int dBToRaw(double dbValue);
+    void resetRawDataRecording();
+    bool getSensorData();
+
+  protected:
+    uint8_t mPresence = -1;
+    float mMoveSpeed = NO_NUM;
+    int8_t mSensitivity = -1;
+    int8_t mScenario = -1;
+    uint8_t getSensorClass() override; // returns unique ID for this sensor type
+    void sensorLoopInternal() override;
+    bool checkSensorConnection() override;
+    float measureValue(MeasureType iMeasureType) override;
+    void sendDefaultSensorValues();
+
+  public:
+    SensorHLKLD2420(uint16_t iMeasureTypes);
+    SensorHLKLD2420(uint16_t iMeasureTypes, uint8_t iAddress);
+    virtual ~SensorHLKLD2420() {}
+
+    //static bool decodePresenceResult(uint8_t iResult, bool &ePresence, uint8_t &eMove, uint8_t &eFall, uint8_t &eAlarm);
+    bool begin() override;
+    uint8_t getI2cSpeed() override;
+    void defaultSensorParameters(int8_t iScenario, uint8_t iSensitivity);
+    // void resetSensor();
+    // void writeSensitivity(uint8_t iValue);
+    // void readSensitivity();
+    // void writeScenario(uint8_t iValue);
+    // void readScenario();
+    void sendCommand(byte command, std::vector<byte> paramter = {});
+};
+#endif
+#endif

--- a/src/SensorHLKLD2420.h
+++ b/src/SensorHLKLD2420.h
@@ -24,6 +24,9 @@ const std::vector<byte> FOOTER_RAW_DATA = {(byte)0xFD, (byte)0xFC, (byte)0xFB, (
 #define CMD_WRITE_MODULE_CONFIG 0x07
 #define CMD_RAW_DATA_MODE 0x12
 
+#define OFFSET_PARAM_RANGE_GATE_MIN 0x00
+#define OFFSET_PARAM_RANGE_GATE_MAX 0x01
+#define OFFSET_PARAM_DELAY_TIME 0x04
 #define OFFSET_PARAM_TRIGGERS 0x10
 #define OFFSET_PARAM_HOLDS 0x20
 
@@ -100,6 +103,7 @@ class SensorHLKLD2420 : public Sensor
     void uartGetPacket();
     int bytesToInt(byte byte1, byte byte2, byte byte3, byte byte4);
     std::vector<byte> intToBytes(int intValue);
+    std::vector<byte> shortToBytes(short shortValue);
     double rawToDb(int rawValue);
     int dBToRaw(double dbValue);
     void resetRawDataRecording();
@@ -109,6 +113,9 @@ class SensorHLKLD2420 : public Sensor
     uint8_t mPresence = -1;
     float mMoveSpeed = NO_NUM;
     int8_t mSensitivity = -1;
+    uint16_t mDelayTime = 30;
+    uint8_t mRangeGateMin = 0;
+    uint8_t mRangeGateMax = 15;
     uint8_t getSensorClass() override; // returns unique ID for this sensor type
     void sensorLoopInternal() override;
     bool checkSensorConnection() override;
@@ -120,10 +127,9 @@ class SensorHLKLD2420 : public Sensor
     SensorHLKLD2420(uint16_t iMeasureTypes, uint8_t iAddress);
     virtual ~SensorHLKLD2420() {}
 
-    //static bool decodePresenceResult(uint8_t iResult, bool &ePresence, uint8_t &eMove, uint8_t &eFall, uint8_t &eAlarm);
     bool begin() override;
     uint8_t getI2cSpeed() override;
-    void defaultSensorParameters(uint8_t iSensitivity);
+    void defaultSensorParameters(uint8_t iSensitivity, uint16_t iDelayTime, uint8_t iRangeGateMin, uint8_t iRangeGateMax);
     // void resetSensor();
     void writeSensitivity(int8_t iSensitivity);
     // void readSensitivity();

--- a/src/SensorHLKLD2420.h
+++ b/src/SensorHLKLD2420.h
@@ -33,9 +33,14 @@ const std::vector<byte> PARAM_READ_DELAY_MAINTAIN = {(byte)0x04, (byte)0x00, (by
 const std::vector<byte> PARAM_RAW_DATA_MODE = {(byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00};
 
 #define CALIBRATION_VALUE_COUNT 100
-#define CALIBRATION_TRIGGER_OFFSET_DB 3
-#define CALIBRATION_HOLD_OFFSET_DB 1.5
+#define CALIBRATION_TRIGGER_OFFSET_DB 5 // = min. sensitivity, range 1 - 5
+#define CALIBRATION_HOLD_OFFSET_DB 2.5  // = min. sensitivity, range 1.5 - 2.5
 
+// these will be deducted from trigger/hold offset based on sensitivity percentage
+// e. g. sensitivity 5 (= 50 %): trigger offset 5-2=3, hold offset 2.5-1=1.5
+// lower offsets = higher sensitivity
+#define SENSITIVIY_TRIGGER_RANGE 4
+#define SENSITIVIY_HOLD_RANGE 2
 
 #define START_INIT 0
 #define START_SENSOR_ACTIVE 1
@@ -88,8 +93,7 @@ class SensorHLKLD2420 : public Sensor
     double rawDataRangeAverage[16];
     int rawDataRecordingCount = 0;
     
-    int8_t mDefaultScenario = 0;
-    int8_t mDefaultSensitivity = 8;
+    int8_t mDefaultSensitivity = 5;
     uint8_t mHfSensorStartupStates = 0;
 
     void uartGetPacket();
@@ -119,12 +123,10 @@ class SensorHLKLD2420 : public Sensor
     //static bool decodePresenceResult(uint8_t iResult, bool &ePresence, uint8_t &eMove, uint8_t &eFall, uint8_t &eAlarm);
     bool begin() override;
     uint8_t getI2cSpeed() override;
-    void defaultSensorParameters(int8_t iScenario, uint8_t iSensitivity);
+    void defaultSensorParameters(uint8_t iSensitivity);
     // void resetSensor();
-    // void writeSensitivity(uint8_t iValue);
+    void writeSensitivity(int8_t iSensitivity);
     // void readSensitivity();
-    // void writeScenario(uint8_t iValue);
-    // void readScenario();
     void sendCommand(byte command, std::vector<byte> paramter = {});
     std::string logPrefix() override;
 };

--- a/src/SensorHLKLD2420.h
+++ b/src/SensorHLKLD2420.h
@@ -126,6 +126,7 @@ class SensorHLKLD2420 : public Sensor
     // void writeScenario(uint8_t iValue);
     // void readScenario();
     void sendCommand(byte command, std::vector<byte> paramter = {});
+    std::string logPrefix() override;
 };
 #endif
 #endif


### PR DESCRIPTION
Initial support for HLK-LD2420 presence sensors which have following advantages:
- Only 3.3 V, ~50 mA and thus no problem to power via KNX bus only.
- Cheap to buy, e. g. here: https://de.aliexpress.com/item/1005005386482664.html
- Full control over calibration.